### PR TITLE
Add server dependent SavedVariables

### DIFF
--- a/LibMotif_Scan.lua
+++ b/LibMotif_Scan.lua
@@ -278,6 +278,7 @@ function LibMotif:Initialize()
                             , self.saved_var_version
                             , nil
                             , self.default
+                            , GetWorldName()  
                             )
         LibMotif.RegisterSlashCommands()
     end


### PR DESCRIPTION
Users tend even more in our times to play on NA and EU servers at the same time, using the same account.
Knowledge should be saved server dependent, else it is not trust worthy.
Thank you